### PR TITLE
글 상세 보기 컨트롤러 객체 이름 변경

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/domain/board/presentation/AdminBoardController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/presentation/AdminBoardController.java
@@ -39,7 +39,7 @@ public class AdminBoardController {
 
     @GetMapping("/{id}")
     public ResponseEntity<DetailBoardResponse> findOne(@PathVariable("id") Long id) {
-        DetailBoardResponse detailBoardResponse = oneBoardService.execute(id);
-        return new ResponseEntity<>(detailBoardResponse, HttpStatus.OK);
+        DetailBoardResponse oneFindById = oneBoardService.execute(id);
+        return new ResponseEntity<>(oneFindById, HttpStatus.OK);
     }
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/presentation/UserBoardController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/presentation/UserBoardController.java
@@ -39,7 +39,7 @@ public class UserBoardController {
 
     @GetMapping("/{id}")
     public ResponseEntity<DetailBoardResponse> findOne(@PathVariable("id") Long id) {
-        DetailBoardResponse detailBoardResponse = oneBoardService.execute(id);
-        return new ResponseEntity<>(detailBoardResponse, HttpStatus.OK);
+        DetailBoardResponse oneFindById = oneBoardService.execute(id);
+        return new ResponseEntity<>(oneFindById, HttpStatus.OK);
     }
 }


### PR DESCRIPTION
- 글 상세 보기에서 사용하는 DetailBoardResponse 객체의 이름을 알기 쉽게 변경