### PR TITLE
컨트롤러들의 return 방식 통일

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/domain/auth/presentation/AuthController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/auth/presentation/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
         userSignUpService.execute(signUpRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @PostMapping("/login")
@@ -41,14 +41,14 @@ public class AuthController {
     @DeleteMapping
     public ResponseEntity<Void> logout(@RequestHeader("Authorization")String accessToken){
         userLogoutService.execute(accessToken);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 
     }
 
     @PatchMapping
     public ResponseEntity<NewTokenResponse> reIssueToken(@RequestHeader("RefreshToken") String token) {
         NewTokenResponse reIssueToken = tokenReissueService.execute(token);
-        return ResponseEntity.ok(reIssueToken);
+        return new ResponseEntity<>(reIssueToken, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/email/presentation/EmailController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/email/presentation/EmailController.java
@@ -22,12 +22,12 @@ public class EmailController {
     @PostMapping
     public ResponseEntity<Void> sendEmail(@RequestBody @Valid EmailSendRequest emailSendRequest) {
         emailSendService.execute(emailSendRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @RequestMapping(method = RequestMethod.HEAD)
     public ResponseEntity<Void> AuthCheck(@Email @RequestParam String email, @RequestParam String authCode) {
         emailCheckService.execute(email, authCode);
-        return ResponseEntity.ok().build();
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/notice/presentation/UserNoticeController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/notice/presentation/UserNoticeController.java
@@ -29,7 +29,7 @@ public class UserNoticeController {
     @GetMapping("/{id}")
     public ResponseEntity<NoticeDetailResponse> findOne(@PathVariable("id") Long id){
         NoticeDetailResponse oneFindById = oneNoticeService.execute(id);
-        return new ResponseEntity<>(oneFindById,HttpStatus.OK);
+        return new ResponseEntity<>(oneFindById, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/user/presentation/UserController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/user/presentation/UserController.java
@@ -3,6 +3,7 @@ package mpersand.Gmuwiki.domain.user.presentation;
 import lombok.RequiredArgsConstructor;
 import mpersand.Gmuwiki.domain.user.presentation.dto.request.ChangePasswordRequest;
 import mpersand.Gmuwiki.domain.user.service.ChangePasswordService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,6 @@ public class UserController {
     @PatchMapping("/password")
     public ResponseEntity<Void> ChangePassword(@RequestBody @Valid ChangePasswordRequest changePasswordRequest) {
         changePasswordService.execute(changePasswordRequest);
-        return ResponseEntity.noContent().build();
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }


### PR DESCRIPTION
- return 부분이 ResponseEntity.ok(body 값) 과 return new ResponseEntity<> 두 방식이 섞여있었음 -> return new ResponseEntity<> 으로 return 방식을 통일하여 코드 내의 일관성 유지