### PR TITLE
테이블의 Cascade 가 적용되지 않음

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/domain/board/entity/BoardRecord.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/entity/BoardRecord.java
@@ -31,7 +31,7 @@ public class BoardRecord {
     @Column(nullable = false)
     private String name;
 
-    @ManyToOne(cascade = CascadeType.REMOVE)
+    @ManyToOne
     @JoinColumn(name = "board_id")
     private Board board;
 

--- a/src/main/java/mpersand/Gmuwiki/domain/board/repository/BoardRecordRepository.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/repository/BoardRecordRepository.java
@@ -12,4 +12,5 @@ public interface BoardRecordRepository extends JpaRepository<BoardRecord, Long> 
 
     boolean existsByTitle(String title);
 
+    void deleteAllByBoard(Board board);
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/service/DeleteBoardAdminService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/service/DeleteBoardAdminService.java
@@ -3,6 +3,7 @@ package mpersand.Gmuwiki.domain.board.service;
 import lombok.RequiredArgsConstructor;
 import mpersand.Gmuwiki.domain.board.entity.Board;
 import mpersand.Gmuwiki.domain.board.exception.BoardNotFoundException;
+import mpersand.Gmuwiki.domain.board.repository.BoardRecordRepository;
 import mpersand.Gmuwiki.domain.board.repository.BoardRepository;
 import mpersand.Gmuwiki.global.annotation.RollbackService;
 
@@ -12,10 +13,14 @@ public class DeleteBoardAdminService {
 
     private final BoardRepository boardRepository;
 
+    private final BoardRecordRepository boardRecordRepository;
+
     public void execute(Long id) {
 
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new BoardNotFoundException());
+
+        boardRecordRepository.deleteAllByBoard(board);
 
         boardRepository.delete(board);
     }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/service/DeleteBoardService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/service/DeleteBoardService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import mpersand.Gmuwiki.domain.board.entity.Board;
 import mpersand.Gmuwiki.domain.board.exception.BoardNotFoundException;
 import mpersand.Gmuwiki.domain.board.exception.BoardAuthorMismatchException;
+import mpersand.Gmuwiki.domain.board.repository.BoardRecordRepository;
 import mpersand.Gmuwiki.domain.board.repository.BoardRepository;
 import mpersand.Gmuwiki.domain.user.entity.User;
 import mpersand.Gmuwiki.global.annotation.RollbackService;
@@ -14,6 +15,8 @@ import mpersand.Gmuwiki.global.util.UserUtil;
 public class DeleteBoardService {
 
     private final BoardRepository boardRepository;
+
+    private final BoardRecordRepository boardRecordRepository;
 
     private final UserUtil userUtil;
 
@@ -27,6 +30,8 @@ public class DeleteBoardService {
         if(!(board.getUser() == user)) {
             throw new BoardAuthorMismatchException();
         }
+
+        boardRecordRepository.deleteAllByBoard(board);
 
         boardRepository.delete(board);
     }


### PR DESCRIPTION
BoardRecord에 @ManyToOne(cascade = CascadeType.REMOVE) 제약 조건을 설정했지만 외래키 접근 설정으로 인해 에러 발생 -> Cascade 옵션을 삭제 하는 대신 DeleteBoardService 에 원글을 지우기 전에 글 기록 테이블을 제거하는 코드 추가