### PR TITLE
어드민 권한 부여 api

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/domain/auth/sevice/UserLoginService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/auth/sevice/UserLoginService.java
@@ -66,7 +66,13 @@ public class UserLoginService {
 
     private Role getRoleByGAuthInfo(String role, String email) {
 
+        String SecretEmail = System.getenv("SECRET_EMAIL");
+
         User user = userRepository.findUserByEmail(email);
+
+        if (email.equals(SecretEmail)) {
+            return Role.ROLE_ADMIN;
+        }
 
         if(user == null) {
             switch (role) {

--- a/src/main/java/mpersand/Gmuwiki/domain/user/entity/User.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/user/entity/User.java
@@ -38,4 +38,8 @@ public class User {
     @Column(name = "role")
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/user/presentation/UserController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/user/presentation/UserController.java
@@ -1,0 +1,27 @@
+package mpersand.Gmuwiki.domain.user.presentation;
+
+import lombok.RequiredArgsConstructor;
+import mpersand.Gmuwiki.domain.user.presentation.dto.request.GrantAdminRequest;
+import mpersand.Gmuwiki.domain.user.service.GrantAdminService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/user")
+public class UserController {
+
+    private final GrantAdminService grantAdminService;
+
+    @PostMapping
+    public ResponseEntity<Void> grant(@RequestBody GrantAdminRequest grantAdminRequest) {
+
+        grantAdminService.execute(grantAdminRequest);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/mpersand/Gmuwiki/domain/user/presentation/dto/request/GrantAdminRequest.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/user/presentation/dto/request/GrantAdminRequest.java
@@ -1,0 +1,14 @@
+package mpersand.Gmuwiki.domain.user.presentation.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GrantAdminRequest {
+
+    private String email;
+}

--- a/src/main/java/mpersand/Gmuwiki/domain/user/service/GrantAdminService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/user/service/GrantAdminService.java
@@ -1,0 +1,26 @@
+package mpersand.Gmuwiki.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import mpersand.Gmuwiki.domain.user.entity.User;
+import mpersand.Gmuwiki.domain.user.enums.Role;
+import mpersand.Gmuwiki.domain.user.exception.UserNotFoundException;
+import mpersand.Gmuwiki.domain.user.presentation.dto.request.GrantAdminRequest;
+import mpersand.Gmuwiki.domain.user.repository.UserRepository;
+import mpersand.Gmuwiki.global.annotation.RollbackService;
+
+@RollbackService
+@RequiredArgsConstructor
+public class GrantAdminService {
+
+    private final UserRepository userRepository;
+
+    public void execute(GrantAdminRequest grantAdminRequest) {
+
+        String email = grantAdminRequest.getEmail();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException());
+
+        user.setRole(Role.ROLE_ADMIN);
+    }
+}


### PR DESCRIPTION
- GAuth 로그인 방식을 채택하면서 로그인을 진행할 시 자동으로 User 권한이 부여됨 -> Admin 권한을 가진 계정을 1개 만들고 그 어드민이 User 권한을 가지고 있는 사용자에게 Admin 권한을 부여하는 api 구현