### PR TITLE
ExceptionFilter 주석 처리

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/global/filter/ExceptionFilter.java
+++ b/src/main/java/mpersand/Gmuwiki/global/filter/ExceptionFilter.java
@@ -48,9 +48,10 @@ public class ExceptionFilter extends OncePerRequestFilter {
         } catch (JwtException | GmuwikiException ex) {
             log.debug("================= [ ExceptionHandlerFilter ] 에서 TokenNotValidException 발생 ===================");
             setErrorResponse(TOKEN_NOT_VALID, response);
-        } catch (Exception ex) {
-            log.debug("================= [ ExceptionHandlerFilter ] 에서 Exception 발생 ===================");
-            setErrorResponse(UNKNOWN_ERROR, response);
+        }
+//        catch (Exception ex) {
+//            log.debug("================= [ ExceptionHandlerFilter ] 에서 Exception 발생 ===================");
+//            setErrorResponse(UNKNOWN_ERROR, response);
         }
     }
-}
+


### PR DESCRIPTION
- ExceptionFilter 에서 알 수 없는 에러를 500 으로 반환하고 있어 조금 더 자세한 오류를 알기 위해 해당 코드를 주석 처리