### PR TITLE
querydsl 을 적용한 검색어 자동완성 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### log ###
+src/main/resources/logs

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,15 @@
+//querydsl
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.9'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'mpersand'
@@ -16,6 +24,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	//gauth
 	maven { url 'https://jitpack.io' }
 }
 
@@ -59,8 +68,28 @@ dependencies {
 
 	//webhook
 	implementation 'com.squareup.okhttp3:okhttp:4.9.1'
+
+	//querydsl
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+//querydsl
+def querydslSrcDir = "$buildDir/generated/querydsl"
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslSrcDir
+}
+sourceSets {
+	main.java.srcDir querydslSrcDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/presentation/AdminBoardController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/presentation/AdminBoardController.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import mpersand.Gmuwiki.domain.board.enums.BoardType;
 import mpersand.Gmuwiki.domain.board.presentation.dto.request.CreateBoardRequest;
 import mpersand.Gmuwiki.domain.board.presentation.dto.request.EditBoardRequest;
+import mpersand.Gmuwiki.domain.board.presentation.dto.request.SearchBoardTitleRequest;
 import mpersand.Gmuwiki.domain.board.presentation.dto.response.DetailBoardResponse;
 import mpersand.Gmuwiki.domain.board.presentation.dto.response.ListBoardRecordResponse;
 import mpersand.Gmuwiki.domain.board.presentation.dto.response.ListBoardResponse;
+import mpersand.Gmuwiki.domain.board.presentation.dto.response.ListSearchBoardResponse;
 import mpersand.Gmuwiki.domain.board.service.*;
 import mpersand.Gmuwiki.global.annotation.RestRequestService;
 import org.springframework.http.HttpStatus;
@@ -33,10 +35,18 @@ public class AdminBoardController {
 
     private final GetBoardRecordDetailService getBoardRecordDetailService;
 
+    private final SearchBoardTitleService searchBoardTitleService;
+
     @PostMapping
     public ResponseEntity<Void> create(@RequestBody @Valid CreateBoardRequest createBoardRequest) {
         createBoardService.execute(createBoardRequest);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ListSearchBoardResponse> searchTitle(@RequestParam("title") SearchBoardTitleRequest searchBoardTitleRequest) {
+        var list = searchBoardTitleService.execute(searchBoardTitleRequest);
+        return new ResponseEntity<>(list, HttpStatus.OK);
     }
 
     @GetMapping

--- a/src/main/java/mpersand/Gmuwiki/domain/board/presentation/UserBoardController.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/presentation/UserBoardController.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import mpersand.Gmuwiki.domain.board.enums.BoardType;
 import mpersand.Gmuwiki.domain.board.presentation.dto.request.CreateBoardRequest;
 import mpersand.Gmuwiki.domain.board.presentation.dto.request.EditBoardRequest;
+import mpersand.Gmuwiki.domain.board.presentation.dto.request.SearchBoardTitleRequest;
 import mpersand.Gmuwiki.domain.board.presentation.dto.response.DetailBoardResponse;
 import mpersand.Gmuwiki.domain.board.presentation.dto.response.ListBoardRecordResponse;
 import mpersand.Gmuwiki.domain.board.presentation.dto.response.ListBoardResponse;
+import mpersand.Gmuwiki.domain.board.presentation.dto.response.ListSearchBoardResponse;
 import mpersand.Gmuwiki.domain.board.service.*;
 import mpersand.Gmuwiki.global.annotation.RestRequestService;
 import org.springframework.http.HttpStatus;
@@ -33,10 +35,18 @@ public class UserBoardController {
 
     private final GetBoardRecordDetailService getBoardRecordDetailService;
 
+    private final SearchBoardTitleService searchBoardTitleService;
+
     @PostMapping
     public ResponseEntity<Void> create(@RequestBody @Valid CreateBoardRequest createBoardRequest) {
         createBoardService.execute(createBoardRequest);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ListSearchBoardResponse> searchTitle(@RequestParam("title") SearchBoardTitleRequest searchBoardTitleRequest) {
+        var list = searchBoardTitleService.execute(searchBoardTitleRequest);
+        return new ResponseEntity<>(list, HttpStatus.OK);
     }
 
     @GetMapping

--- a/src/main/java/mpersand/Gmuwiki/domain/board/presentation/dto/request/SearchBoardTitleRequest.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/presentation/dto/request/SearchBoardTitleRequest.java
@@ -1,0 +1,14 @@
+package mpersand.Gmuwiki.domain.board.presentation.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchBoardTitleRequest {
+
+    private String title;
+}

--- a/src/main/java/mpersand/Gmuwiki/domain/board/presentation/dto/response/ListSearchBoardResponse.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/presentation/dto/response/ListSearchBoardResponse.java
@@ -1,0 +1,15 @@
+package mpersand.Gmuwiki.domain.board.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ListSearchBoardResponse {
+
+    List<SearchBoardResponse> boardTitleList;
+}

--- a/src/main/java/mpersand/Gmuwiki/domain/board/presentation/dto/response/SearchBoardResponse.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/presentation/dto/response/SearchBoardResponse.java
@@ -1,0 +1,24 @@
+package mpersand.Gmuwiki.domain.board.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import mpersand.Gmuwiki.domain.board.entity.Board;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SearchBoardResponse {
+
+    private Long id;
+
+    private String title;
+
+    public static SearchBoardResponse toResponse(Board board) {
+
+        return SearchBoardResponse.builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/mpersand/Gmuwiki/domain/board/repository/BoardRepository.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/repository/BoardRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
 
     List<Board> findByBoardType(BoardType boardType);
 

--- a/src/main/java/mpersand/Gmuwiki/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/repository/BoardRepositoryCustom.java
@@ -1,0 +1,10 @@
+package mpersand.Gmuwiki.domain.board.repository;
+
+import mpersand.Gmuwiki.domain.board.entity.Board;
+
+import java.util.List;
+
+public interface BoardRepositoryCustom {
+
+    List<Board> findByTitle(String title);
+}

--- a/src/main/java/mpersand/Gmuwiki/domain/board/repository/impl/BoardRepositoryCustomImpl.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/repository/impl/BoardRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package mpersand.Gmuwiki.domain.board.repository.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mpersand.Gmuwiki.domain.board.entity.Board;
+import mpersand.Gmuwiki.domain.board.entity.QBoard;
+import mpersand.Gmuwiki.domain.board.repository.BoardRepositoryCustom;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Board> findByTitle(String title) {
+
+        return jpaQueryFactory
+                .selectFrom(QBoard.board)
+                .where(QBoard.board.title.contains(title))
+                .orderBy(QBoard.board.title.asc())
+                .limit(12)
+                .fetch();
+        }
+    }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/service/SearchBoardTitleService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/service/SearchBoardTitleService.java
@@ -1,0 +1,37 @@
+package mpersand.Gmuwiki.domain.board.service;
+
+import lombok.RequiredArgsConstructor;
+import mpersand.Gmuwiki.domain.board.entity.Board;
+import mpersand.Gmuwiki.domain.board.presentation.dto.request.SearchBoardTitleRequest;
+import mpersand.Gmuwiki.domain.board.presentation.dto.response.ListSearchBoardResponse;
+import mpersand.Gmuwiki.domain.board.repository.BoardRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static mpersand.Gmuwiki.domain.board.presentation.dto.response.SearchBoardResponse.toResponse;
+
+@Service
+@Transactional(readOnly = true, rollbackFor = Exception.class)
+@RequiredArgsConstructor
+public class SearchBoardTitleService {
+
+    private final BoardRepository boardRepository;
+
+    public ListSearchBoardResponse execute(SearchBoardTitleRequest searchBoardTitleRequest) {
+
+        List<Board> titles = boardRepository.findByTitle(searchBoardTitleRequest.getTitle());
+
+        ListSearchBoardResponse listSearchBoardResponse = ListSearchBoardResponse.builder()
+                .boardTitleList(
+                        titles.stream()
+                                .map(board -> toResponse(board))
+                                .collect(Collectors.toList())
+                )
+                .build();
+
+        return listSearchBoardResponse;
+    }
+}

--- a/src/main/java/mpersand/Gmuwiki/global/config/querydsl/QuerydslConfig.java
+++ b/src/main/java/mpersand/Gmuwiki/global/config/querydsl/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package mpersand.Gmuwiki.global.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/mpersand/Gmuwiki/global/config/s3/S3Config.java
+++ b/src/main/java/mpersand/Gmuwiki/global/config/s3/S3Config.java
@@ -1,4 +1,4 @@
-package mpersand.Gmuwiki.global.aws.config;
+package mpersand.Gmuwiki.global.config.s3;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;

--- a/src/test/java/mpersand/Gmuwiki/GMuwikiApplicationTests.java
+++ b/src/test/java/mpersand/Gmuwiki/GMuwikiApplicationTests.java
@@ -3,7 +3,7 @@ package mpersand.Gmuwiki;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = GMuwikiApplicationTests.class)
 class GMuwikiApplicationTests {
 
 	@Test


### PR DESCRIPTION
- 기존에 클라이언트에서 맡기로 한 검색어 자동완성 기능을 서버에서 쿼리문을 사용해 api 를 구현, 사용하도록 기능 구현