### PR TITLE
글 수정 중 생기는 오류 수정 + 리팩터링

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/domain/board/entity/Board.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/entity/Board.java
@@ -25,7 +25,7 @@ public class Board {
     @Column(name = "board_id")
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String title;
 
     @Column(nullable = false)

--- a/src/main/java/mpersand/Gmuwiki/domain/board/entity/BoardRecord.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/entity/BoardRecord.java
@@ -22,7 +22,7 @@ public class BoardRecord {
     @Column(name = "board_record_id")
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String title;
 
     @Column(nullable = false)

--- a/src/main/java/mpersand/Gmuwiki/domain/board/exception/BoardNotChangeException.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/exception/BoardNotChangeException.java
@@ -1,0 +1,13 @@
+package mpersand.Gmuwiki.domain.board.exception;
+
+import lombok.Getter;
+import mpersand.Gmuwiki.global.error.ErrorCode;
+import mpersand.Gmuwiki.global.error.GmuwikiException;
+
+@Getter
+public class BoardNotChangeException extends GmuwikiException {
+
+    public BoardNotChangeException() {
+        super(ErrorCode.BOARD_NOT_CHANGE);
+    }
+}

--- a/src/main/java/mpersand/Gmuwiki/domain/board/repository/BoardRecordRepository.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/repository/BoardRecordRepository.java
@@ -10,7 +10,5 @@ public interface BoardRecordRepository extends JpaRepository<BoardRecord, Long> 
 
     List<BoardRecord> findByBoard(Board board);
 
-    boolean existsByTitle(String title);
-
     void deleteAllByBoard(Board board);
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/service/EditBoardService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/service/EditBoardService.java
@@ -3,9 +3,11 @@ package mpersand.Gmuwiki.domain.board.service;
 import lombok.RequiredArgsConstructor;
 import mpersand.Gmuwiki.domain.board.entity.Board;
 import mpersand.Gmuwiki.domain.board.entity.BoardRecord;
+import mpersand.Gmuwiki.domain.board.exception.BoardNotChangeException;
 import mpersand.Gmuwiki.domain.board.exception.ExistTitleException;
 import mpersand.Gmuwiki.domain.board.presentation.dto.request.EditBoardRequest;
 import mpersand.Gmuwiki.domain.board.repository.BoardRecordRepository;
+import mpersand.Gmuwiki.domain.board.repository.BoardRepository;
 import mpersand.Gmuwiki.domain.user.entity.User;
 import mpersand.Gmuwiki.global.annotation.RollbackService;
 import mpersand.Gmuwiki.global.util.BoardUtil;
@@ -14,6 +16,8 @@ import mpersand.Gmuwiki.global.util.UserUtil;
 @RequiredArgsConstructor
 @RollbackService
 public class EditBoardService {
+
+    private final BoardRepository boardRepository;
 
     private final BoardRecordRepository boardRecordRepository;
 
@@ -27,7 +31,9 @@ public class EditBoardService {
 
         User user = userUtil.currentUser();
 
-        if(boardRecordRepository.existsByTitle(editBoardRequest.getTitle())) {
+        if (board.getTitle().equals(editBoardRequest.getTitle()) && board.getContent().equals(editBoardRequest.getContent())) {
+            throw new BoardNotChangeException();
+        } else if (!board.getTitle().equals(editBoardRequest.getTitle()) && boardRepository.existsByTitle(editBoardRequest.getTitle())) {
             throw new ExistTitleException();
         }
 

--- a/src/main/java/mpersand/Gmuwiki/global/error/ErrorCode.java
+++ b/src/main/java/mpersand/Gmuwiki/global/error/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     BOARD_NOT_FOUND("게시글을 찾을 수 없습니다.", 404),
     MISMATCH_BOARD_AUTHOR("내가 작성한 글이 아닙니다.", 403),
     ALREADY_EXIST_TITLE("이미 존재하는 제목입니다.", 409),
+    BOARD_NOT_CHANGE("달라진 수정사항이 없습니다.", 403),
 
     //BOARD RECORD
     BOARD_RECORD_NOT_FOUND("게시글의 기록을 찾을 수 없습니다.", 404),

--- a/src/main/java/mpersand/Gmuwiki/global/error/ErrorCode.java
+++ b/src/main/java/mpersand/Gmuwiki/global/error/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     BOARD_NOT_FOUND("게시글을 찾을 수 없습니다.", 404),
     MISMATCH_BOARD_AUTHOR("내가 작성한 글이 아닙니다.", 403),
     ALREADY_EXIST_TITLE("이미 존재하는 제목입니다.", 409),
-    BOARD_NOT_CHANGE("달라진 수정사항이 없습니다.", 403),
+    BOARD_NOT_CHANGE("달라진 수정사항이 없습니다.", 400),
 
     //BOARD RECORD
     BOARD_RECORD_NOT_FOUND("게시글의 기록을 찾을 수 없습니다.", 404),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${DDL_AUTO_TYPE}
     generate-ddl: true
 
   main:


### PR DESCRIPTION
- 글 수정 시 기존에 존재하던 제목 중복 검사가 제대로 작동하지 않던 오류 수정
- 글 수정 시 제목이 아닌 내용만 수정하려고 할 때 의도하지 않은 ExistTitleException() 이 발생하던 것을 수정
- 글 수정 시 제목과 내용 모두 변화가 없을 때 BoardNotChangeException() 이 발생하도록 추가
- ddl-auto 설정 변경