### PR TITLE
글 내용 크기 제한 삭제

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/domain/board/entity/Board.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/entity/Board.java
@@ -28,7 +28,7 @@ public class Board {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 16000)
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/mpersand/Gmuwiki/domain/board/entity/BoardRecord.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/entity/BoardRecord.java
@@ -25,7 +25,7 @@ public class BoardRecord {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 16000)
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/mpersand/Gmuwiki/domain/inquiry/entity/Inquiry.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/inquiry/entity/Inquiry.java
@@ -25,7 +25,7 @@ public class Inquiry {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 16000)
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/mpersand/Gmuwiki/domain/notice/entity/Notice.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/notice/entity/Notice.java
@@ -26,7 +26,7 @@ public class Notice {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 16000)
     private String content;
 
     @Column(nullable = false)


### PR DESCRIPTION
- String 타입이 sql 테이블에 들어가면 varchar 로 변환되는데 이 varchar 는 255 자의 제한을 기본값으로 가져 글이 길어지면 오류가 발생했음 -> Column 에 length 제한을 직접 설정(16000자..)해 오류 수정