### PR TITLE
글 역사 로직 변경

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/domain/board/entity/Board.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/entity/Board.java
@@ -50,9 +50,8 @@ public class Board {
     @LastModifiedDate
     private LocalDateTime editedDate;
 
-    public void update(EditBoardRequest editBoardRequest, String name) {
+    public void update(EditBoardRequest editBoardRequest) {
         this.title = editBoardRequest.getTitle();
         this.content = editBoardRequest.getContent();
-        this.name = name;
     }
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/entity/BoardRecord.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/entity/BoardRecord.java
@@ -3,7 +3,6 @@ package mpersand.Gmuwiki.domain.board.entity;
 import lombok.*;
 import mpersand.Gmuwiki.domain.board.enums.BoardType;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
@@ -40,7 +39,4 @@ public class BoardRecord {
 
     @CreatedDate
     private LocalDateTime createdDate;
-
-    @LastModifiedDate
-    private LocalDateTime editedDate;
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/service/CreateBoardService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/service/CreateBoardService.java
@@ -2,10 +2,12 @@ package mpersand.Gmuwiki.domain.board.service;
 
 import lombok.RequiredArgsConstructor;
 import mpersand.Gmuwiki.domain.board.entity.Board;
+import mpersand.Gmuwiki.domain.board.entity.BoardRecord;
 import mpersand.Gmuwiki.domain.board.enums.BoardDetailType;
 import mpersand.Gmuwiki.domain.board.enums.BoardType;
 import mpersand.Gmuwiki.domain.board.exception.ExistTitleException;
 import mpersand.Gmuwiki.domain.board.presentation.dto.request.CreateBoardRequest;
+import mpersand.Gmuwiki.domain.board.repository.BoardRecordRepository;
 import mpersand.Gmuwiki.domain.board.repository.BoardRepository;
 import mpersand.Gmuwiki.domain.user.entity.User;
 import mpersand.Gmuwiki.global.annotation.RollbackService;
@@ -20,6 +22,8 @@ public class CreateBoardService {
     private final UserUtil userUtil;
 
     private final BoardRepository boardRepository;
+
+    private final BoardRecordRepository boardRecordRepository;
 
     public void execute(CreateBoardRequest createBoardRequest) {
 
@@ -40,6 +44,17 @@ public class CreateBoardService {
                 .editedDate(LocalDateTime.now())
                 .build();
 
+        BoardRecord boardRecord = BoardRecord.builder()
+                .title(board.getTitle())
+                .content(board.getContent())
+                .name(board.getName())
+                .boardType(board.getBoardType())
+                .createdDate(board.getCreatedDate())
+                .board(board)
+                .build();
+
         boardRepository.save(board);
+
+        boardRecordRepository.save(boardRecord);
     }
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/service/EditBoardService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/service/EditBoardService.java
@@ -38,17 +38,16 @@ public class EditBoardService {
         }
 
         BoardRecord boardRecord = BoardRecord.builder()
-                .title(board.getTitle())
-                .content(board.getContent())
-                .name(board.getName())
+                .title(editBoardRequest.getTitle())
+                .content(editBoardRequest.getContent())
+                .name(user.getName())
                 .boardType(board.getBoardType())
-                .createdDate(board.getCreatedDate())
-                .editedDate(board.getEditedDate())
+                .createdDate(board.getEditedDate())
                 .board(board)
                 .build();
 
         boardRecordRepository.save(boardRecord);
 
-        board.update(editBoardRequest, user.getName());
+        board.update(editBoardRequest);
     }
 }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/service/GetBoardRecordDetailService.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/service/GetBoardRecordDetailService.java
@@ -23,7 +23,6 @@ public class GetBoardRecordDetailService {
                 .title(boardRecord.getTitle())
                 .content(boardRecord.getContent())
                 .createdDate(boardRecord.getCreatedDate())
-                .editedDate(boardRecord.getEditedDate())
                 .build();
 
         return detailBoardResponse;


### PR DESCRIPTION
- 글 작성 시 글 역사 글도 같이 최초 생성되도록 변경
- 글이 수정될 때 글의 이전 글이 글 역사 페이지에 생기는 것이 아닌 수정 글이 같이 생성되도록 변경