### PR TITLE
글 카테고리에 프로젝트 관련 항목 추가

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/domain/board/enums/BoardDetailType.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/enums/BoardDetailType.java
@@ -9,7 +9,8 @@ public enum BoardDetailType {
     MAJOR, CA,
     MAJORS,
     TWENTY_FIRST, TWENTY_SECOND, TWENTY_THIRD,
-    JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEPT, OCT, NOV, DEC;
+    JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEPT, OCT, NOV, DEC,
+    TEAM, INDIVIDUAL;
 
     @JsonCreator
     public static BoardDetailType from(String s) { return BoardDetailType.valueOf(s.toUpperCase()); }

--- a/src/main/java/mpersand/Gmuwiki/domain/board/enums/BoardType.java
+++ b/src/main/java/mpersand/Gmuwiki/domain/board/enums/BoardType.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum BoardType {
 
-    STUDENT, TEACHER, CLUB, MAJOR, INCIDENT, SCHEDULE;
+    STUDENT, TEACHER, CLUB, MAJOR, INCIDENT, SCHEDULE, PROJECT;
 
     @JsonCreator
     public static BoardType from(String s) { return BoardType.valueOf(s.toUpperCase()); }


### PR DESCRIPTION
- 글 카테고리에 프로젝트 관련 항목 추가 ( BoardType 에 PROJECT 카테고리 추가, BoardDetailType 에 PROJECT 세부 카테고리인TEAM, INDIVIDUAL 추가 )