### PR TITLE
유료 도메인 만료에 따른 CORS 설정 변경

### DIFF
--- a/src/main/java/mpersand/Gmuwiki/global/web/WebConfig.java
+++ b/src/main/java/mpersand/Gmuwiki/global/web/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry corsRegistry) {
 
         corsRegistry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "https://www.gmuwiki.com", "https://gumwiki-dev.vercel.app")
+                .allowedOrigins("http://localhost:3000", "https://gmuwiki.vercel.app", "https://gumwiki-dev.vercel.app")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true)


### PR DESCRIPTION
유료 도메인 만료에 따른 CORS 설정 변경 ( 유료 도메인 -> vercel 무료 도메인으로 교체 )